### PR TITLE
Added get_artist and get_track

### DIFF
--- a/src/data_access/SpotifyAPI.java
+++ b/src/data_access/SpotifyAPI.java
@@ -91,4 +91,48 @@ public class SpotifyAPI {
         System.out.println(jsonResponse);
         return jsonResponse;
     }
+
+    public JSONObject get_artist(String id, String accessToken) {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("https://api.spotify.com/v1/artists/" + id))
+            .header("Authorization", "Bearer " + accessToken)
+            .method("GET", HttpRequest.BodyPublishers.noBody())
+            .build();
+
+        HttpResponse<String> response = null;
+        JSONObject jsonResponse = null;
+
+        try {
+            response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            jsonResponse = new JSONObject(response.body());
+        } catch (InterruptedException | IOException e) {
+            e.printStackTrace();
+        }
+
+        System.out.println(jsonResponse);
+        return jsonResponse;
+    }
+
+    public JSONObject get_track(String id, String accessToken) {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("https://api.spotify.com/v1/tracks/" + id))
+            .header("Authorization", "Bearer " + accessToken)
+            .method("GET", HttpRequest.BodyPublishers.noBody())
+            .build();
+
+        HttpResponse<String> response = null;
+        JSONObject jsonResponse = null;
+
+        try {
+            response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            jsonResponse = new JSONObject(response.body());
+        } catch (InterruptedException | IOException e) {
+            e.printStackTrace();
+        }
+
+        System.out.println(jsonResponse);
+        return jsonResponse;
+    }
 }


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->

Added the get_artist and get_track methods to the SpotifyAPI so that services in the application are able to retrieve track and artist information upon receiving their artist and track ids.

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->

We need to retrieve images and song information of our artists and tracks, meaning that after retrieving their ids from the search method, we need to use get_artist and get_track to get this information. 

## Your Changes

<!-- Describe your changes here. -->
Added get_artist and get_track to SpotifyAPI.


**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [X] New feature (non-breaking change which adds functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [X] Coverage tests
- [X] Coding style (conforms to Google Java Style Guide)
- [X] Especially follows section 7 (Javadoc is present for every public class, public or protected member)
- [X] Especially follows section 4.6 (Multiple consecutive blank lines are not encouraged)
- [X] Correctness (follows CA and SOLID, is a reasonable and not overly complicated solution, etc.)
- [X] Description of pull request is clear, consise, and reasonably detailed
